### PR TITLE
Fix Error in ffmpeg command

### DIFF
--- a/code/chapter-2/2-what-does-my-neural-network-think.ipynb
+++ b/code/chapter-2/2-what-does-my-neural-network-think.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ffmpeg -framerate 25 -i data/kitchen_output/result-%04d.jpg kitchen-output.mp4"
+    "!ffmpeg -framerate 25 -i data/kitchen_output/result_%04d.jpg kitchen-output.mp4"
    ]
   },
   {


### PR DESCRIPTION
The filename is saved as kitchen_output/result_*.jpg, but the command is given as result-%04d.jpg.
Fixes Issue :
Could find no file with path 'kitchen_output/result-%04d.jpg' and index in the range 0-4