### PR TITLE
Fix deprecated dataset split usage

### DIFF
--- a/code/chapter-5/1-develop-tool.ipynb
+++ b/code/chapter-5/1-develop-tool.ipynb
@@ -308,12 +308,11 @@
     "        )\n",
     "        # Here we have defined how to split the original train dataset into train and val\n",
     "        # Use 90% as train dataset and 10% as validation dataset\n",
-    "        split_train, split_val = tfds.Split.TRAIN.subsplit(weighted=[9, 1])\n",
     "        train, info_train = tfds.load(dataset_name,\n",
-    "                                      split=split_train,\n",
+    "                                      split='train[:90%]',\n",
     "                                      with_info=True)\n",
     "        val, info_val = tfds.load(dataset_name,\n",
-    "                                  split=split_val,\n",
+    "                                  split='train[90%:]',\n",
     "                                  with_info=True)\n",
     "        NUM_CLASSES = info_train.features['label'].num_classes\n",
     "        # The total number of classes in training dataset should either be equal to or more than the total number of classes in validation dataset\n",
@@ -443,7 +442,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Model defination for training from scratch"
+    "### Model definition for training from scratch"
    ]
   },
   {


### PR DESCRIPTION
The TensorFlow Datasets API that we were using appears to have been deprecated in newer versions of TensorFlow, causing an error:

`AssertionError: Unrecognized instruction format: NamedSplit('train')(tfds.percent[0:90])`