### PR TITLE
Fix issue 163 and 164 in 1_feature_extraction.ipynb

### DIFF
--- a/code/chapter-4/1_feature_extraction.ipynb
+++ b/code/chapter-4/1_feature_extraction.ipynb
@@ -1,293 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 2",
-      "language": "python",
-      "name": "python2"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 2
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython2",
-      "version": "2.7.10"
-    },
-    "toc": {
-      "base_numbering": 1,
-      "nav_menu": {},
-      "number_sections": true,
-      "sideBar": true,
-      "skip_h1_title": false,
-      "title_cell": "Table of Contents",
-      "title_sidebar": "Contents",
-      "toc_cell": false,
-      "toc_position": {},
-      "toc_section_display": true,
-      "toc_window_display": false
-    },
-    "colab": {
-      "name": "Copy of 1-feature-extraction.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "accelerator": "GPU",
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "2f0c84e6e48b40cb9f1360ba4451513c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_470d8a8b00c5475684ab84b55c79b760",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_a0ffda7bcf1a46a4bdd6352c43cfda61",
-              "IPY_MODEL_f80ec0bf78de458995da4f9c964f3722"
-            ]
-          }
-        },
-        "470d8a8b00c5475684ab84b55c79b760": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "width": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "overflow": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "overflow_y": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "align_self": null,
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "a0ffda7bcf1a46a4bdd6352c43cfda61": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "IntProgressModel",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_9792cd696fa74cc68ef6b35095fb8685",
-            "_view_module": "@jupyter-widgets/controls",
-            "_dom_classes": [],
-            "orientation": "horizontal",
-            "min": 0,
-            "bar_style": "success",
-            "max": 8677,
-            "_model_name": "IntProgressModel",
-            "_model_module_version": "1.5.0",
-            "value": 8677,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_4d80db8732434d119c3f3b3bb8469ce9",
-            "description": ""
-          }
-        },
-        "f80ec0bf78de458995da4f9c964f3722": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_fe1544db2c8e4df2a5c7097575da68ab",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "100% 8677/8677 [06:16&lt;00:00, 23.04it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_145e7cf97a5844a48e321c8a4878d13b"
-          }
-        },
-        "9792cd696fa74cc68ef6b35095fb8685": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "4d80db8732434d119c3f3b3bb8469ce9": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "width": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "overflow": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "overflow_y": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "align_self": null,
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "fe1544db2c8e4df2a5c7097575da68ab": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "145e7cf97a5844a48e321c8a4878d13b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "width": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "overflow": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "overflow_y": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "align_self": null,
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        }
-      }
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -342,28 +53,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "-_byh3zWnz6c"
       },
+      "outputs": [],
       "source": [
         "!mkdir -p ../../datasets\n",
         "!pip install gdown\n",
-        "!gdown https://drive.google.com/uc?id=137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp --output ../../datasets/caltech101.tar.gz\n",
+        "!gdown \"https://drive.google.com/uc?id=137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp\" --output ../../datasets/caltech101.tar.gz\n",
         "!tar -xvzf ../../datasets/caltech101.tar.gz --directory ../../datasets\n",
         "!mv ../../datasets/101_ObjectCategories ../../datasets/caltech101\n",
         "!rm -rf ../../datasets/caltech101/BACKGROUND_Google"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 14,
       "metadata": {
         "collapsed": true,
-        "scrolled": false,
-        "id": "yN9yirdLnz6d"
+        "id": "yN9yirdLnz6d",
+        "scrolled": false
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "from numpy.linalg import norm\n",
@@ -383,9 +96,7 @@
         "from tensorflow.keras.applications.inception_v3 import InceptionV3\n",
         "from tensorflow.keras.models import Model\n",
         "from tensorflow.keras.layers import Input, Flatten, Dense, Dropout, GlobalAveragePooling2D\n"
-      ],
-      "execution_count": 2,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -398,10 +109,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
       "metadata": {
         "collapsed": true,
         "id": "n39Tv0YZnz6e"
       },
+      "outputs": [],
       "source": [
         "def model_picker(name):\n",
         "    if (name == 'vgg16'):\n",
@@ -439,9 +152,7 @@
         "    else:\n",
         "        print(\"Specified model not available\")\n",
         "    return model"
-      ],
-      "execution_count": 3,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -454,29 +165,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 16,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "UCz180_jnz6g",
         "outputId": "b6d47be1-b290-46b1-9e54-235b5ba0d2d3"
       },
+      "outputs": [],
       "source": [
         "model_architecture = 'resnet'\n",
         "model = model_picker(model_architecture)"
-      ],
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Downloading data from https://github.com/keras-team/keras-applications/releases/download/resnet/resnet50_weights_tf_dim_ordering_tf_kernels_notop.h5\n",
-            "94773248/94765736 [==============================] - 2s 0us/step\n",
-            "94781440/94765736 [==============================] - 2s 0us/step\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -490,10 +191,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
       "metadata": {
         "collapsed": true,
         "id": "2Fc9vtRenz6g"
       },
+      "outputs": [],
       "source": [
         "def extract_features(img_path, model):\n",
         "    input_shape = (224, 224, 3)\n",
@@ -506,9 +209,7 @@
         "    flattened_features = features.flatten()\n",
         "    normalized_features = flattened_features / norm(flattened_features)\n",
         "    return normalized_features"
-      ],
-      "execution_count": 5,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -521,21 +222,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 17,
       "metadata": {
         "id": "qC_isBQ7okco"
       },
+      "outputs": [],
       "source": [
         "try:\n",
         "  import google.colab\n",
         "  IS_COLAB_ENV = True\n",
         "except:\n",
         "  IS_COLAB_ENV = False"
-      ],
-      "execution_count": 6,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 18,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -543,48 +245,38 @@
         "id": "jU3c7aAbqR-P",
         "outputId": "7cc823ea-5d84-4eb6-ab0a-acc777ba21be"
       },
+      "outputs": [],
       "source": [
         "IMG_PATH = '../../sample-images/cat.jpg'\n",
         "if IS_COLAB_ENV:\n",
         "  !curl https://raw.githubusercontent.com/PracticalDL/Practical-Deep-Learning-Book/master/sample-images/cat.jpg --output cat.jpg\n",
         "  IMG_PATH = 'cat.jpg'"
-      ],
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
-            "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-            "\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  661k  100  661k    0     0  6964k      0 --:--:-- --:--:-- --:--:-- 6964k\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 20,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "_USxAyninz6h",
         "outputId": "c2c588db-95cc-4d55-a686-1ce5a11bc99f"
       },
-      "source": [
-        "features = extract_features('cat.jpg', model)\n",
-        "print(\"Total length of features for one image: \", len(features))"
-      ],
-      "execution_count": 8,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
-            "2048\n"
-          ],
-          "name": "stdout"
+            "1/1 [==============================] - 1s 1s/step\n",
+            "Total length of features for one image:  2048\n"
+          ]
         }
+      ],
+      "source": [
+        "features = extract_features(IMG_PATH, model)\n",
+        "print(\"Total length of features for one image: \", len(features))"
       ]
     },
     {
@@ -598,26 +290,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "Rs8nZZCLnz6i",
         "outputId": "cb7d8dba-ec9c-4fc0-ee23-864f2e66bfb9"
       },
+      "outputs": [],
       "source": [
-        "%timeit features = extract_features('cat.jpg', model)"
-      ],
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "10 loops, best of 3: 81.4 ms per loop\n"
-          ],
-          "name": "stdout"
-        }
+        "%timeit features = extract_features(IMG_PATH, model)"
       ]
     },
     {
@@ -642,10 +326,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 22,
       "metadata": {
         "collapsed": true,
         "id": "biSAC49dnz6j"
       },
+      "outputs": [],
       "source": [
         "extensions = ['.jpg', '.JPG', '.jpeg', '.JPEG', '.png', '.PNG']\n",
         "\n",
@@ -660,9 +346,7 @@
         "                else:\n",
         "                  print(filepath)\n",
         "    return file_list"
-      ],
-      "execution_count": 10,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -675,6 +359,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 23,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -682,27 +367,26 @@
         "id": "XC75Z2Dau77Z",
         "outputId": "9140e060-cd2a-42a2-fd6c-a1d782822e28"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "8677\n"
+          ]
+        }
+      ],
       "source": [
         "# path to the your datasets\n",
         "root_dir = '../../datasets/caltech101'\n",
         "filenames = sorted(get_file_list(root_dir))\n",
         "print(len(filenames))"
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "8677\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 84,
@@ -717,40 +401,15 @@
             "145e7cf97a5844a48e321c8a4878d13b"
           ]
         },
+        "collapsed": true,
         "id": "8gfnWvUNnz6j",
         "outputId": "9563b02d-607e-4b47-a823-d345875b146d"
       },
+      "outputs": [],
       "source": [
         "standard_feature_list = []\n",
         "for i in tqdm_notebook(range(len(filenames))):\n",
         "    standard_feature_list.append(extract_features(filenames[i], model))"
-      ],
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "2f0c84e6e48b40cb9f1360ba4451513c",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "HBox(children=(IntProgress(value=0, max=8677), HTML(value=u'')))"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "8677\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -764,14 +423,36 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "gsEQDJuKnz6k",
         "outputId": "255b0843-9fd2-4947-94d5-fd400f729eba"
       },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING: Logging before flag parsing goes to stderr.\n",
+            "W0725 00:00:57.965632 140262955202432 deprecation.py:323] From <ipython-input-14-4a2e3dbd89a6>:16: predict_generator (from tensorflow.python.keras.engine.training) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Please use Model.predict, which supports generators.\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Found 8677 images belonging to 101 classes.\n",
+            "(8677, 'num images')\n",
+            "(67, 'num epochs')\n"
+          ]
+        }
+      ],
       "source": [
         "batch_size = 128\n",
         "datagen = tensorflow.keras.preprocessing.image.ImageDataGenerator(preprocessing_function=preprocess_input)\n",
@@ -779,6 +460,7 @@
         "generator = datagen.flow_from_directory(root_dir,\n",
         "                                        target_size=(224, 224),\n",
         "                                        class_mode=None,\n",
+        "                                        batch_size=batch_size,\n",
         "                                        shuffle=False)\n",
         "\n",
         "num_images = len(generator.filenames)\n",
@@ -788,40 +470,30 @@
         "feature_list = []\n",
         "feature_list = model.predict_generator(generator, num_epochs)\n",
         "end_time = time.time()"
-      ],
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "WARNING: Logging before flag parsing goes to stderr.\n",
-            "W0725 00:00:57.965632 140262955202432 deprecation.py:323] From <ipython-input-14-4a2e3dbd89a6>:16: predict_generator (from tensorflow.python.keras.engine.training) is deprecated and will be removed in a future version.\n",
-            "Instructions for updating:\n",
-            "Please use Model.predict, which supports generators.\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "Found 8677 images belonging to 101 classes.\n",
-            "(8677, 'num images')\n",
-            "(67, 'num epochs')\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "oMPld5V0nz6k",
         "outputId": "f552f9ef-123e-4f46-f11d-3bfa8ca96247"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "('Num images   = ', 8677)\n",
+            "('Shape of feature_list = ', (2144, 2048))\n",
+            "('Time taken in sec = ', 8.890146017074585)\n"
+          ]
+        }
+      ],
       "source": [
         "for i, features in enumerate(feature_list):\n",
         "    feature_list[i] = features / norm(features)\n",
@@ -831,18 +503,6 @@
         "print(\"Num images   = \", len(generator.classes))\n",
         "print(\"Shape of feature_list = \", feature_list.shape)\n",
         "print(\"Time taken in sec = \", end_time - start_time)"
-      ],
-      "execution_count": 18,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "('Num images   = ', 8677)\n",
-            "('Shape of feature_list = ', (2144, 2048))\n",
-            "('Time taken in sec = ', 8.890146017074585)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -921,23 +581,25 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "JXxQ9oi7nz6m"
       },
+      "outputs": [],
       "source": [
         "filenames = [root_dir + '/' + s for s in generator.filenames]"
-      ],
-      "execution_count": 19,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "code_folding": [],
         "collapsed": true,
         "id": "6azYdG-Anz6m"
       },
+      "outputs": [],
       "source": [
         "pickle.dump(generator.classes, open('./data/class_ids-caltech101.pickle',\n",
         "                                    'wb'))\n",
@@ -945,9 +607,7 @@
         "pickle.dump(\n",
         "    feature_list,\n",
         "    open('./data/features-caltech101-' + model_architecture + '.pickle', 'wb'))"
-      ],
-      "execution_count": 20,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -960,44 +620,54 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "tdq3wz3Qnz6m"
       },
+      "outputs": [],
       "source": [
         "TRAIN_SAMPLES = 8677\n",
         "NUM_CLASSES = 101\n",
         "IMG_WIDTH, IMG_HEIGHT = 224, 224"
-      ],
-      "execution_count": 21,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "ePCFVIHznz6n"
       },
+      "outputs": [],
       "source": [
         "train_datagen = ImageDataGenerator(preprocessing_function=preprocess_input,\n",
         "                                   rotation_range=20,\n",
         "                                   width_shift_range=0.2,\n",
         "                                   height_shift_range=0.2,\n",
         "                                   zoom_range=0.2)"
-      ],
-      "execution_count": 22,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "Yh_NVL5Tnz6n",
         "outputId": "129fa193-a5fa-4e02-9db0-f74525b5f9b2"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Found 8677 images belonging to 101 classes.\n"
+          ]
+        }
+      ],
       "source": [
         "train_generator = train_datagen.flow_from_directory(root_dir,\n",
         "                                                    target_size=(IMG_WIDTH,\n",
@@ -1005,24 +675,16 @@
         "                                                    shuffle=True,\n",
         "                                                    seed=12345,\n",
         "                                                    class_mode='categorical')"
-      ],
-      "execution_count": 23,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Found 8677 images belonging to 101 classes.\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "bR6oZOPlnz6n"
       },
+      "outputs": [],
       "source": [
         "def model_maker():\n",
         "    base_model = ResNet50(include_top=False,\n",
@@ -1036,33 +698,22 @@
         "    custom_model = Dropout(0.5)(custom_model)\n",
         "    predictions = Dense(NUM_CLASSES, activation='softmax')(custom_model)\n",
         "    return Model(inputs=input, outputs=predictions)"
-      ],
-      "execution_count": 24,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "Sghlu4Rfnz6n",
         "outputId": "19c97bb7-bc5b-4de0-e48c-60c088998823"
       },
-      "source": [
-        "model_finetuned = model_maker()\n",
-        "model_finetuned.compile(loss='categorical_crossentropy',\n",
-        "              optimizer=tensorflow.keras.optimizers.Adam(0.001),\n",
-        "              metrics=['acc'])\n",
-        "model_finetuned.fit_generator(\n",
-        "    train_generator,\n",
-        "    steps_per_epoch=math.ceil(float(TRAIN_SAMPLES) / batch_size),\n",
-        "    epochs=10)"
-      ],
-      "execution_count": 25,
       "outputs": [
         {
+          "name": "stderr",
           "output_type": "stream",
           "text": [
             "W0725 00:01:11.765636 140262955202432 deprecation.py:323] From <ipython-input-25-3632d4ca8dfa>:8: fit_generator (from tensorflow.python.keras.engine.training) is deprecated and will be removed in a future version.\n",
@@ -1072,10 +723,10 @@
             "  ...\n",
             "    to  \n",
             "  ['...']\n"
-          ],
-          "name": "stderr"
+          ]
         },
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "Train for 68.0 steps\n",
@@ -1099,45 +750,67 @@
             "68/68 [==============================] - 26s 383ms/step - loss: 1.5282 - acc: 0.5896\n",
             "Epoch 10/10\n",
             "68/68 [==============================] - 25s 366ms/step - loss: 1.5246 - acc: 0.5979\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "<tensorflow.python.keras.callbacks.History at 0x7f8ebb7ec790>"
             ]
           },
+          "execution_count": 25,
           "metadata": {
             "tags": []
           },
-          "execution_count": 25
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "model_finetuned = model_maker()\n",
+        "model_finetuned.compile(loss='categorical_crossentropy',\n",
+        "              optimizer=tensorflow.keras.optimizers.Adam(0.001),\n",
+        "              metrics=['acc'])\n",
+        "model_finetuned.fit_generator(\n",
+        "    train_generator,\n",
+        "    steps_per_epoch=math.ceil(float(TRAIN_SAMPLES) / batch_size),\n",
+        "    epochs=10)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "GcPDg7Wunz6o"
       },
+      "outputs": [],
       "source": [
         "model_finetuned.save('./data/model-finetuned.h5')"
-      ],
-      "execution_count": 26,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "collapsed": true,
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "collapsed": true,
         "id": "cSE2qbwtnz6o",
         "outputId": "dd898777-459f-44f2-b561-c2ed9792c4ef"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2144\n",
+            "('Num images   = ', 2144)\n",
+            "('Shape of feature_list = ', (2144, 101))\n",
+            "('Time taken in sec = ', 8.284640073776245)\n"
+          ]
+        }
+      ],
       "source": [
         "start_time = time.time()\n",
         "feature_list_finetuned = []\n",
@@ -1152,34 +825,310 @@
         "print(\"Num images   = \", len(feature_list_finetuned) )\n",
         "print(\"Shape of feature_list = \", feature_list.shape)\n",
         "print(\"Time taken in sec = \", end_time - start_time)"
-      ],
-      "execution_count": 27,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "2144\n",
-            "('Num images   = ', 2144)\n",
-            "('Shape of feature_list = ', (2144, 101))\n",
-            "('Time taken in sec = ', 8.284640073776245)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "L8FvRo-6nz6o"
       },
+      "outputs": [],
       "source": [
         "pickle.dump(\n",
         "    feature_list,\n",
         "    open('./data/features-caltech101-resnet-finetuned.pickle', 'wb'))"
-      ],
-      "execution_count": 28,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "name": "Copy of 1-feature-extraction.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "lewagon",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.12"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "145e7cf97a5844a48e321c8a4878d13b": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "2f0c84e6e48b40cb9f1360ba4451513c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_a0ffda7bcf1a46a4bdd6352c43cfda61",
+              "IPY_MODEL_f80ec0bf78de458995da4f9c964f3722"
+            ],
+            "layout": "IPY_MODEL_470d8a8b00c5475684ab84b55c79b760"
+          }
+        },
+        "470d8a8b00c5475684ab84b55c79b760": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "4d80db8732434d119c3f3b3bb8469ce9": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "9792cd696fa74cc68ef6b35095fb8685": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "a0ffda7bcf1a46a4bdd6352c43cfda61": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "IntProgressModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "IntProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_4d80db8732434d119c3f3b3bb8469ce9",
+            "max": 8677,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_9792cd696fa74cc68ef6b35095fb8685",
+            "value": 8677
+          }
+        },
+        "f80ec0bf78de458995da4f9c964f3722": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_145e7cf97a5844a48e321c8a4878d13b",
+            "placeholder": "​",
+            "style": "IPY_MODEL_fe1544db2c8e4df2a5c7097575da68ab",
+            "value": "100% 8677/8677 [06:16&lt;00:00, 23.04it/s]"
+          }
+        },
+        "fe1544db2c8e4df2a5c7097575da68ab": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
3 changes in this notebook to fix #163 #164
1. Quoting paths to prevent zsh shells erroring with `zsh:1: no matches found: https://drive.google.com/uc?id=137RyRjvTBkBiIfeYBNZBtViDHQ6_Ewsp` because it treats ? as glob character.
![image](https://user-images.githubusercontent.com/29853829/226551456-ceae99bb-f17c-4478-8518-e3c57708513c.png)

2. Convert `cat.jpg` that assumes user is running on colab into `IMG_PATH` that works on both colab and local
![image](https://user-images.githubusercontent.com/29853829/226552561-cfae46ae-1003-4098-956e-ad1c9acd07e3.png)

3. Make generator produce 68 * 128 instead of 68 * 32 images
![image](https://user-images.githubusercontent.com/29853829/226553173-00e9af70-5035-4f86-8375-378ec3a70f7e.png)

@sidgan 
There are a few difficulties in me making PR on notebook files.

1. **No local GPU** 
Later notebooks depend on data from previous notebooks. I have no GPU locally to produce those data. If I use colab for GPU, I have to add drive mounting code that messes up the notebook with extra cells. Current workflow is I generate necessary assets on colab then paste the changes individually from colab notebook to local notebook before commit. This means I never ran the local notebook top down, so there may be errors still. 

2. **Cell output management**
It seems some cells have instructive output and some outputs are purposely deleted. It's best for the authors to run through the notebook again and decide what to show on the github version. I don't want to show my own filepaths in the output too. 

3. **Diffing notebooks** 
I tried ReviewNB but it gave a single chunk of red followed by a chunk of green because somehow it thinks the entire notebook changed. I eventually used nbdime locally, but if you know how I can use ReviewNB correctly, or any better way to communicate please advise.

---
# Unaddressed issues
**Outputs are still wrong**
```
Found 8677 images belonging to 101 classes.
(8677, 'num images')
(67, 'num epochs')
```
At this cell i think it should show (68, 'num epochs') because ceil(8677/128) = 68 not 67. It looks like someone ran it without ceil first then added the ceil code without running again so the output was stale, which is another reason I hope authors can run the notebook and give a final check on outputs.   

**Python2 in metadata**
```
  "metadata": {
    "kernelspec": {
      "display_name": "Python 2",
      "language": "python",
      "name": "python2"
    }
```
From json version of the ipynb we can see it is using python 2. The notebooks also open by default on python 2 in colab. 
Changing it to python 3 may prevent frustration in users trying to debug a common issue, where syntax errors happen because python 2's print expected print 'hi' but the user think they're using python 3 and codes print('hi')
